### PR TITLE
Add browser training controls and model loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ An intelligent Snake game with sophisticated AI algorithms and real-time paramet
 - **Multiple Grid Sizes**: From 10x10 to 60x60 for different challenges
 - **Speed Control**: Adjust game speed from 1ms to 500ms
 - **Live Strategy Display**: See what the AI is thinking in real-time
+- **Browser Training Sandbox**: Train multiple environments simultaneously in the browser, toggle auto mode, and load saved models without running Node.js
 
 ### 🎨 Modern Design
 - **Glassmorphism UI**: Beautiful modern interface with blur effects

--- a/index.html
+++ b/index.html
@@ -384,6 +384,64 @@
       font-weight: 600;
       color: var(--accent);
     }
+    .training-controls {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .env-input {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 1rem;
+    }
+    .env-input input[type="number"] {
+      background: var(--darker);
+      border: 1px solid var(--primary);
+      border-radius: 0.8rem;
+      padding: 0.5rem 0.75rem;
+      color: var(--text);
+      font-weight: 600;
+      width: 110px;
+      text-align: center;
+      box-shadow: 0 0 10px rgba(102, 126, 234, 0.3);
+    }
+    .training-buttons {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.75rem;
+    }
+    .training-status {
+      margin-top: 1rem;
+    }
+    .training-status .status-item {
+      border-bottom: none;
+    }
+    .button.secondary {
+      background: linear-gradient(135deg, rgba(102, 126, 234, 0.2), rgba(118, 75, 162, 0.2));
+      color: var(--text);
+      border: 1px solid var(--primary);
+      box-shadow: none;
+    }
+    .button.secondary:hover {
+      box-shadow: 0 6px 20px rgba(102, 126, 234, 0.3);
+    }
+    .model-status {
+      font-size: 0.85rem;
+      opacity: 0.8;
+      margin-top: 0.5rem;
+    }
+    .training-meta {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 0.5rem 1rem;
+      margin-top: 0.75rem;
+      font-size: 0.9rem;
+    }
+    .training-meta span {
+      font-weight: 600;
+      color: var(--accent);
+    }
     /* AI Status messages */
     #statusMessages {
       background: var(--darker);
@@ -647,7 +705,49 @@
               <p id="compactStepStatus"></p>
             </div>
           </div>
-          
+
+          <div class="controls-section">
+            <h3>Browser Training</h3>
+            <div class="training-controls">
+              <div class="env-input">
+                <label for="envCountInput">Environment count:</label>
+                <input type="number" id="envCountInput" min="1" max="64" value="4">
+              </div>
+              <div class="training-buttons">
+                <button id="startTrainingBtn" class="button">🚀 Start batch</button>
+                <button id="toggleAutoBtn" class="button">🤖 Enable auto mode</button>
+                <button id="stopTrainingBtn" class="button danger">⏹ Stop</button>
+              </div>
+              <div>
+                <button id="loadModelBtn" class="button secondary" type="button">📁 Load model</button>
+                <input type="file" id="modelFileInput" accept="application/json" style="display:none;">
+                <p id="modelStatus" class="model-status">No model loaded.</p>
+              </div>
+              <div class="training-meta">
+                <div>Status: <span id="trainingStatusText">Idle</span></div>
+                <div>Active envs: <span id="trainingEnvCount">4</span></div>
+              </div>
+            </div>
+            <div class="status-display training-status">
+              <div class="status-item">
+                <span class="status-label">Episodes:</span>
+                <span id="trainingEpisodes" class="status-value">0</span>
+              </div>
+              <div class="status-item">
+                <span class="status-label">Perfect runs:</span>
+                <span id="trainingPerfect" class="status-value">0</span>
+              </div>
+              <div class="status-item">
+                <span class="status-label">Best length:</span>
+                <span id="trainingBest" class="status-value">0</span>
+              </div>
+              <div class="status-item">
+                <span class="status-label">Average length:</span>
+                <span id="trainingAverage" class="status-value">0</span>
+              </div>
+            </div>
+          </div>
+
         </div>
       </div>
     </div>
@@ -869,6 +969,7 @@
         hamMode=false, compactMode=false, compactModeSteps=0,
         loopHandle=null, currentStrategy="Initializing";
     let gameRunning = false;
+    let trainingManager;
     /* ===== PAGE NAVIGATION ===== */
     const navLinks = document.querySelectorAll('.nav-link');
     const pages = document.querySelectorAll('.page');
@@ -921,6 +1022,7 @@
           document.getElementById('endgameSlider').max = Math.max(100, Math.floor((COLS * ROWS) * 0.4));
         }
         restartGame();
+        if (trainingManager) trainingManager.handleSettingsChanged();
       }
     }
     colsSlider.addEventListener('input', updateGridSize);
@@ -947,33 +1049,65 @@
       document.getElementById('compactValue').textContent = COMPACT_MODE_MAX_STEPS;
     });
     /* ===== RESTART FUNCTION ===== */
-    function restartGame() {
-      snake = [];
-      snakeSet = new Set();
+    function spawnFruitForState(state){
+      const free=[];
+      for(let y=0;y<ROWS;y++){
+        for(let x=0;x<COLS;x++){
+          if(!state.snakeSet.has(`${x},${y}`)) free.push({x,y});
+        }
+      }
+      return free.length ? free[(Math.random()*free.length)|0] : {x:-1,y:-1};
+    }
+    function createFreshState(){
+      const state = {
+        snake: [],
+        snakeSet: new Set(),
+        fruit: {x:-1,y:-1},
+        prevFruitDist: Infinity,
+        noProgressMoves: 0,
+        lastMoves: [],
+        windowMoves: [],
+        loopDetected: false,
+        loopStreak: 0,
+        hamMode: false,
+        compactMode: false,
+        compactModeSteps: 0,
+        loopCountAdjust: 0,
+        currentStrategy: "Initializing"
+      };
       const sx = Math.floor(COLS/2), sy = Math.floor(ROWS/2);
       if (COLS >= 5) {
-        snake.push({x:sx-2,y:sy},{x:sx-1,y:sy},{x:sx,y:sy});
+        state.snake.push({x:sx-2,y:sy},{x:sx-1,y:sy},{x:sx,y:sy});
       } else if (COLS >= 3) {
-        snake.push({x:sx-1,y:sy},{x:sx,y:sy});
+        state.snake.push({x:sx-1,y:sy},{x:sx,y:sy});
       } else {
-        snake.push({x:sx,y:sy});
+        state.snake.push({x:sx,y:sy});
       }
-      snake.reverse();
-      snake.forEach(p => snakeSet.add(`${p.x},${p.y}`));
+      state.snake.reverse();
+      state.snakeSet = new Set(state.snake.map(p => `${p.x},${p.y}`));
+      state.fruit = spawnFruitForState(state);
+      if(state.fruit && state.fruit.x >= 0){
+        state.prevFruitDist = Math.abs(state.snake[0].x - state.fruit.x) + Math.abs(state.snake[0].y - state.fruit.y);
+      }
+      return state;
+    }
+    function restartGame() {
+      const fresh = createFreshState();
+      snake = fresh.snake;
+      snakeSet = fresh.snakeSet;
+      fruit = fresh.fruit;
+      prevFruitDist = fresh.prevFruitDist;
+      noProgressMoves = fresh.noProgressMoves;
+      lastMoves = fresh.lastMoves;
+      windowMoves = fresh.windowMoves;
+      loopDetected = fresh.loopDetected;
+      loopStreak = fresh.loopStreak;
+      hamMode = fresh.hamMode;
+      compactMode = fresh.compactMode;
+      compactModeSteps = fresh.compactModeSteps;
+      loopCountAdjust = fresh.loopCountAdjust;
+      currentStrategy = fresh.currentStrategy;
       HAM = buildHamilton();
-      prevFruitDist = Infinity;
-      noProgressMoves = 0;
-      lastMoves = [];
-      windowMoves = [];
-      loopDetected = false;
-      loopStreak = 0;
-      hamMode = false;
-      compactMode = false;
-      compactModeSteps = 0;
-      loopCountAdjust = 0;
-      currentStrategy = "Initializing";
-      fruit = spawnFruit();
-      if (fruit.x >= 0) prevFruitDist = Math.abs(snake[0].x - fruit.x) + Math.abs(snake[0].y - fruit.y);
       if (loopHandle) clearInterval(loopHandle);
       gameRunning = true;
       draw();
@@ -1555,6 +1689,441 @@
         }
       }
       draw();
+    }
+    /* ===== TRAINING UTILITIES ===== */
+    function internalStep(){
+      if(!snake.length){
+        return { done: true, reason: 'empty', length: 0, ate: false };
+      }
+      const nxt = getNext();
+      if(!nxt){
+        return { done: true, reason: 'no-move', length: snake.length, ate: false };
+      }
+      if(nxt.x < 0 || nxt.x >= COLS || nxt.y < 0 || nxt.y >= ROWS){
+        return { done: true, reason: 'wall', length: snake.length, ate: false };
+      }
+      const ate = fruit && fruit.x >= 0 && nxt.x === fruit.x && nxt.y === fruit.y;
+      if(!ate){
+        const tail = snake.pop();
+        if(tail) snakeSet.delete(`${tail.x},${tail.y}`);
+      }
+      snake.unshift({x: nxt.x, y: nxt.y});
+      snakeSet.add(`${nxt.x},${nxt.y}`);
+      let done = false;
+      let reason = null;
+      if(ate){
+        loopCountAdjust = 0;
+        if(snake.length === COLS * ROWS){
+          fruit = {x: -1, y: -1};
+          done = true;
+          reason = 'perfect';
+        } else {
+          fruit = spawnFruit();
+          prevFruitDist = (fruit.x >= 0)
+            ? Math.abs(snake[0].x - fruit.x) + Math.abs(snake[0].y - fruit.y)
+            : Infinity;
+          noProgressMoves = 0;
+        }
+      }
+      return { done, reason, ate, length: snake.length };
+    }
+    function applyTrainingState(state){
+      snake = state.snake;
+      snakeSet = state.snakeSet;
+      fruit = state.fruit;
+      prevFruitDist = state.prevFruitDist;
+      noProgressMoves = state.noProgressMoves;
+      lastMoves = state.lastMoves;
+      windowMoves = state.windowMoves;
+      loopDetected = state.loopDetected;
+      loopStreak = state.loopStreak;
+      hamMode = state.hamMode;
+      compactMode = state.compactMode;
+      compactModeSteps = state.compactModeSteps;
+      loopCountAdjust = state.loopCountAdjust;
+      currentStrategy = state.currentStrategy;
+    }
+    function syncTrainingState(state){
+      state.fruit = fruit;
+      state.prevFruitDist = prevFruitDist;
+      state.noProgressMoves = noProgressMoves;
+      state.loopDetected = loopDetected;
+      state.loopStreak = loopStreak;
+      state.hamMode = hamMode;
+      state.compactMode = compactMode;
+      state.compactModeSteps = compactModeSteps;
+      state.loopCountAdjust = loopCountAdjust;
+      state.currentStrategy = currentStrategy;
+    }
+    function captureInteractiveState(){
+      return {
+        snake: snake.map(p => ({x:p.x,y:p.y})),
+        snakeSet: Array.from(snakeSet),
+        fruit: fruit ? {x:fruit.x,y:fruit.y} : null,
+        prevFruitDist,
+        noProgressMoves,
+        lastMoves: lastMoves.map(p => ({x:p.x,y:p.y})),
+        windowMoves: windowMoves.slice(),
+        loopDetected,
+        loopStreak,
+        hamMode,
+        compactMode,
+        compactModeSteps,
+        loopCountAdjust,
+        currentStrategy,
+        gameRunning
+      };
+    }
+    function restoreInteractiveState(snapshot){
+      if(!snapshot) return;
+      snake = snapshot.snake.map(p => ({x:p.x,y:p.y}));
+      snakeSet = new Set(snapshot.snakeSet);
+      fruit = snapshot.fruit ? {x:snapshot.fruit.x,y:snapshot.fruit.y} : {x:-1,y:-1};
+      prevFruitDist = snapshot.prevFruitDist;
+      noProgressMoves = snapshot.noProgressMoves;
+      lastMoves = snapshot.lastMoves.map(p => ({x:p.x,y:p.y}));
+      windowMoves = snapshot.windowMoves.slice();
+      loopDetected = snapshot.loopDetected;
+      loopStreak = snapshot.loopStreak;
+      hamMode = snapshot.hamMode;
+      compactMode = snapshot.compactMode;
+      compactModeSteps = snapshot.compactModeSteps;
+      loopCountAdjust = snapshot.loopCountAdjust;
+      currentStrategy = snapshot.currentStrategy;
+      if(loopHandle){
+        clearInterval(loopHandle);
+        loopHandle = null;
+      }
+      gameRunning = snapshot.gameRunning;
+      HAM = buildHamilton();
+      draw();
+      if(gameRunning){
+        loopHandle = setInterval(update, SPEED);
+      }
+    }
+    class BrowserTrainingManager {
+      constructor(){
+        this.envCount = 4;
+        this.envs = [];
+        this.autoMode = false;
+        this.isRunning = false;
+        this.loopRef = null;
+        this.stepsPerFrame = 400;
+        this.frameBudget = 8;
+        this.stats = { episodes: 0, totalLength: 0, bestLength: 0, perfects: 0 };
+        this.interactiveBackup = null;
+        this.statusMessage = 'Idle';
+        this.dom = {
+          envCountInput: document.getElementById('envCountInput'),
+          startBtn: document.getElementById('startTrainingBtn'),
+          autoBtn: document.getElementById('toggleAutoBtn'),
+          stopBtn: document.getElementById('stopTrainingBtn'),
+          episodes: document.getElementById('trainingEpisodes'),
+          best: document.getElementById('trainingBest'),
+          average: document.getElementById('trainingAverage'),
+          perfect: document.getElementById('trainingPerfect'),
+          status: document.getElementById('trainingStatusText'),
+          envLabel: document.getElementById('trainingEnvCount'),
+          loadModelBtn: document.getElementById('loadModelBtn')
+        };
+        this.dom.envCountInput.addEventListener('input', (e) => {
+          const value = parseInt(e.target.value, 10);
+          this.setEnvCount(Number.isNaN(value) ? this.envCount : value);
+        });
+        this.dom.startBtn.addEventListener('click', () => this.startBatch());
+        this.dom.autoBtn.addEventListener('click', () => this.toggleAuto());
+        this.dom.stopBtn.addEventListener('click', () => this.stop());
+        this.updateTrainingUI();
+      }
+      resetStats(){
+        this.stats = { episodes: 0, totalLength: 0, bestLength: 0, perfects: 0 };
+      }
+      prepareEnvironments(){
+        this.envs = Array.from({length: this.envCount}, () => ({
+          state: createFreshState(),
+          done: false,
+          steps: 0
+        }));
+      }
+      setEnvCount(count){
+        const clamped = Math.max(1, Math.min(64, Math.floor(count)));
+        this.envCount = clamped;
+        if(this.dom.envCountInput.value !== String(clamped)){
+          this.dom.envCountInput.value = clamped;
+        }
+        this.dom.envLabel.textContent = clamped;
+        if(this.isRunning){
+          this.restartCurrentRun();
+        } else {
+          this.updateTrainingUI();
+        }
+      }
+      startBatch(){
+        this.autoMode = false;
+        this.start(false);
+      }
+      start(auto){
+        if(this.isRunning){
+          this.stop(false, this.statusMessage);
+        }
+        this.autoMode = !!auto;
+        this.resetStats();
+        this.prepareEnvironments();
+        this.interactiveBackup = captureInteractiveState();
+        if(loopHandle){
+          clearInterval(loopHandle);
+          loopHandle = null;
+        }
+        gameRunning = false;
+        this.isRunning = true;
+        this.statusMessage = this.autoMode ? 'Auto mode running' : `Batch running (0/${this.envCount})`;
+        this.updateTrainingUI();
+        this.loopRef = requestAnimationFrame(() => this.loop());
+      }
+      toggleAuto(){
+        if(this.autoMode){
+          this.autoMode = false;
+          this.statusMessage = this.isRunning ? `Batch running (0/${this.envCount})` : 'Idle';
+          this.updateTrainingUI();
+        } else {
+          if(this.isRunning){
+            this.autoMode = true;
+            this.statusMessage = 'Auto mode running';
+            this.updateTrainingUI();
+          } else {
+            this.start(true);
+          }
+        }
+      }
+      loop(){
+        if(!this.isRunning){
+          return;
+        }
+        let steps = 0;
+        const start = performance.now();
+        while(steps < this.stepsPerFrame && performance.now() - start < this.frameBudget){
+          let progressed = false;
+          for(const env of this.envs){
+            if(!this.isRunning) break;
+            if(env.done) continue;
+            applyTrainingState(env.state);
+            const result = internalStep();
+            syncTrainingState(env.state);
+            env.steps++;
+            steps++;
+            progressed = true;
+            if(result.done){
+              this.stats.episodes++;
+              this.stats.totalLength += result.length;
+              if(result.length > this.stats.bestLength) this.stats.bestLength = result.length;
+              if(result.reason === 'perfect') this.stats.perfects++;
+              if(this.autoMode){
+                env.state = createFreshState();
+                env.done = false;
+                env.steps = 0;
+              } else {
+                env.done = true;
+              }
+              this.updateTrainingUI();
+            }
+            if(steps >= this.stepsPerFrame || performance.now() - start >= this.frameBudget){
+              break;
+            }
+          }
+          if(!this.autoMode && this.envs.every(e => e.done)){
+            this.stop(false, 'Batch complete');
+            return;
+          }
+          if(!progressed){
+            break;
+          }
+        }
+        if(this.isRunning){
+          this.loopRef = requestAnimationFrame(() => this.loop());
+        }
+      }
+      stop(resetAuto = true, message = 'Idle'){
+        if(this.loopRef){
+          cancelAnimationFrame(this.loopRef);
+          this.loopRef = null;
+        }
+        if(resetAuto){
+          this.autoMode = false;
+        }
+        const hadBackup = !!this.interactiveBackup;
+        this.isRunning = false;
+        this.statusMessage = message;
+        if(hadBackup){
+          restoreInteractiveState(this.interactiveBackup);
+          this.interactiveBackup = null;
+        } else {
+          draw();
+        }
+        this.envs = [];
+        this.updateTrainingUI();
+      }
+      restartCurrentRun(){
+        if(!this.isRunning) return;
+        const auto = this.autoMode;
+        this.stop(false, this.statusMessage);
+        this.autoMode = auto;
+        this.start(auto);
+      }
+      handleSettingsChanged(){
+        if(this.isRunning){
+          this.restartCurrentRun();
+        } else {
+          this.updateTrainingUI();
+        }
+      }
+      updateTrainingUI(){
+        const avg = this.stats.episodes ? (this.stats.totalLength / this.stats.episodes).toFixed(1) : '0';
+        this.dom.episodes.textContent = this.stats.episodes;
+        this.dom.best.textContent = this.stats.bestLength;
+        this.dom.average.textContent = avg;
+        this.dom.perfect.textContent = this.stats.perfects;
+        this.dom.envLabel.textContent = this.envCount;
+        if(this.isRunning){
+          if(this.autoMode){
+            this.statusMessage = 'Auto mode running';
+          } else {
+            const done = this.envs.filter(e => e.done).length;
+            this.statusMessage = `Batch running (${done}/${this.envCount})`;
+          }
+        }
+        this.dom.status.textContent = this.statusMessage;
+        this.dom.startBtn.disabled = this.isRunning;
+        this.dom.stopBtn.disabled = !this.isRunning;
+        this.dom.envCountInput.disabled = this.isRunning;
+        this.dom.autoBtn.textContent = this.autoMode ? '🤖 Disable auto mode' : '🤖 Enable auto mode';
+        if(this.dom.loadModelBtn){
+          this.dom.loadModelBtn.disabled = this.isRunning;
+        }
+      }
+    }
+    trainingManager = new BrowserTrainingManager();
+    const loadModelBtn = document.getElementById('loadModelBtn');
+    const modelFileInput = document.getElementById('modelFileInput');
+    const modelStatus = document.getElementById('modelStatus');
+    if(modelStatus) modelStatus.style.color = 'var(--text)';
+    function firstNumber(...values){
+      for(const value of values){
+        if(typeof value === 'number' && !Number.isNaN(value)) return value;
+        if(typeof value === 'string' && value.trim() !== ''){
+          const num = Number(value);
+          if(!Number.isNaN(num)) return num;
+        }
+      }
+      return undefined;
+    }
+    function clampToSlider(val, slider){
+      const min = parseInt(slider.min, 10);
+      const max = parseInt(slider.max, 10);
+      const step = slider.step ? Number(slider.step) : 1;
+      const normalized = Math.round(Number(val) / step) * step;
+      return Math.max(min, Math.min(max, normalized));
+    }
+    function applyLoadedModel(data){
+      if(!data || typeof data !== 'object') throw new Error('Invalid model format');
+      const envCfg = data.env || data.grid || data.board;
+      if(envCfg){
+        const colVal = firstNumber(envCfg.cols, envCfg.columns, envCfg.width);
+        const rowVal = firstNumber(envCfg.rows, envCfg.height);
+        let needsUpdate = false;
+        if(typeof colVal === 'number'){
+          colsSlider.value = clampToSlider(colVal, colsSlider);
+          needsUpdate = true;
+        }
+        if(typeof rowVal === 'number'){
+          rowsSlider.value = clampToSlider(rowVal, rowsSlider);
+          needsUpdate = true;
+        }
+        if(needsUpdate) updateGridSize();
+      }
+      const params = data.params || data.parameters || data.hyperparams;
+      if(params){
+        const loopVal = firstNumber(params.loop, params.loopThreshold, params.loop_streak, params.loopStreak);
+        if(typeof loopVal === 'number'){
+          const clamped = clampToSlider(loopVal, loopThreshSlider);
+          LOOP_STREAK_THRESHOLD = clamped;
+          loopThreshSlider.value = clamped;
+          document.getElementById('loopThreshValue').textContent = clamped;
+        }
+        const noProgVal = firstNumber(params.noProgress, params.no_progress, params.noProgressThreshold, params.progressThreshold);
+        if(typeof noProgVal === 'number'){
+          const clamped = clampToSlider(noProgVal, progThreshSlider);
+          NO_PROGRESS_THRESHOLD = clamped;
+          progThreshSlider.value = clamped;
+          document.getElementById('progThreshValue').textContent = clamped;
+        }
+        const endgameVal = firstNumber(params.endgame, params.endgameThreshold);
+        if(typeof endgameVal === 'number'){
+          const clamped = clampToSlider(endgameVal, endgameSlider);
+          ENDGAME_THRESHOLD = clamped;
+          endgameSlider.value = clamped;
+          document.getElementById('endgameValue').textContent = clamped;
+        }
+        const compactVal = firstNumber(params.compact, params.compactSteps, params.compact_mode_steps);
+        if(typeof compactVal === 'number'){
+          const clamped = clampToSlider(compactVal, compactSlider);
+          COMPACT_MODE_MAX_STEPS = clamped;
+          compactSlider.value = clamped;
+          document.getElementById('compactValue').textContent = clamped;
+        }
+        const speedVal = firstNumber(params.speed, params.interval, params.delay);
+        if(typeof speedVal === 'number'){
+          changeSpeed(speedVal);
+        }
+      }
+      const topSpeed = firstNumber(data.speed);
+      if(typeof topSpeed === 'number'){
+        changeSpeed(topSpeed);
+      }
+      if(data.training && trainingManager){
+        const envCountVal = firstNumber(data.training.envCount, data.training.envs, data.training.count);
+        if(typeof envCountVal === 'number'){
+          trainingManager.setEnvCount(envCountVal);
+        }
+        if(typeof data.training.auto === 'boolean'){
+          trainingManager.autoMode = data.training.auto;
+          trainingManager.updateTrainingUI();
+        }
+      }
+    }
+    if(loadModelBtn && modelFileInput){
+      loadModelBtn.addEventListener('click', () => {
+        if(loadModelBtn.disabled) return;
+        modelFileInput.click();
+      });
+      modelFileInput.addEventListener('change', (event) => {
+        const file = event.target.files[0];
+        if(!file) return;
+        const reader = new FileReader();
+        reader.onload = () => {
+          try {
+            const data = JSON.parse(reader.result);
+            applyLoadedModel(data);
+            if(modelStatus){
+              modelStatus.textContent = `Loaded: ${file.name}`;
+              modelStatus.style.color = '#4ade80';
+            }
+          } catch(err) {
+            console.error('Failed to load model', err);
+            if(modelStatus){
+              modelStatus.textContent = 'Failed to load model. Check the JSON structure.';
+              modelStatus.style.color = '#ef4444';
+            }
+          }
+        };
+        reader.onerror = () => {
+          if(modelStatus){
+            modelStatus.textContent = 'Could not read the selected file.';
+            modelStatus.style.color = '#ef4444';
+          }
+        };
+        reader.readAsText(file);
+        modelFileInput.value = '';
+      });
     }
     /* ===== SPEED CONTROLS & STARTUP ===== */
     document.getElementById('slowerBtn').onclick = () => changeSpeed(SPEED + SPEED_STEP);


### PR DESCRIPTION
## Summary
- add a browser-only training control panel with environment count, auto mode toggle, and live stats
- implement a headless training manager with model loading helpers and update the README with the new sandbox feature

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d1aae3c9348324a10959cc381002b5