### PR TITLE
Add experience guide panel under score explaining UI and endgame parameter

### DIFF
--- a/index.html
+++ b/index.html
@@ -266,6 +266,39 @@
       border: 1px solid var(--glass-border);
     }
 
+    .info-panel {
+      width: 100%;
+      max-width: 700px;
+    }
+
+    .info-panel p {
+      font-size: 0.85rem;
+      line-height: 1.5;
+      opacity: 0.9;
+      margin-bottom: 0.75rem;
+    }
+
+    .info-panel ul {
+      list-style: none;
+      padding-left: 0;
+      display: grid;
+      gap: 0.6rem;
+      margin: 0;
+    }
+
+    .info-panel li {
+      display: flex;
+      gap: 0.6rem;
+      font-size: 0.82rem;
+      line-height: 1.4;
+    }
+
+    .info-panel li::before {
+      content: '✦';
+      color: var(--accent);
+      margin-top: 0.05rem;
+    }
+
     .strategy-title {
       font-size: 0.75rem;
       text-transform: uppercase;
@@ -447,6 +480,23 @@
             <div class="stat-label">Progress</div>
             <div class="stat-value" id="progress">0%</div>
           </div>
+        </div>
+
+        <div class="panel info-panel">
+          <h3>Experience Guide</h3>
+          <p>
+            You are watching the AI navigate toward apples while keeping a safe Hamiltonian path
+            ready. The live stats and strategy feed show whether it is exploring, compressing space,
+            or riding the safety loop.
+          </p>
+          <ul>
+            <li><strong>What you can adjust:</strong> speed, grid size, and AI thresholds that control when it switches
+            to loop safety or compact mode.</li>
+            <li><strong>Try manual mode:</strong> pause the autopilot and take control to feel how tight the pathing becomes
+            as the board fills up.</li>
+            <li><strong>Endgame threshold matters:</strong> raising it makes the AI pivot earlier to the endgame safety
+            cycle, which is often crucial to avoid trapping itself when only a few cells remain.</li>
+          </ul>
         </div>
       </div>
 


### PR DESCRIPTION
### Motivation
- Provide a short, visible explanation of the demo so visitors understand what the AI is doing, which controls matter, and why the `Endgame Threshold` is important to avoid self-trapping.

### Description
- Add a new `.info-panel` block and styles in `index.html` to render an “Experience Guide” panel beneath the score/progress tiles that matches the existing glassmorphism UI.
- The panel text explains what the user is seeing, which controls they can adjust (speed, grid size, AI thresholds), suggests trying manual mode, and calls out that the endgame parameter is often crucial.

### Testing
- Started a local server with `python -m http.server 8000` and validated the change by taking a full-page screenshot using a Playwright script (`sync_playwright` + `page.screenshot`), which completed successfully.
- No unit tests were added because this is a static UI/content update; visual verification via the screenshot was used instead.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697deb050ff48324afcd8fa832ba090f)